### PR TITLE
Include stdio to fix debug builds

### DIFF
--- a/include/fpattern/debug.h
+++ b/include/fpattern/debug.h
@@ -1,7 +1,7 @@
 /******************************************************************************
 * debug.h
 *
-* Copyright ©1997-2015 by David R. Tribble, all rights reserved.
+* Copyright Â©1997-2015 by David R. Tribble, all rights reserved.
 */
 
 
@@ -34,6 +34,8 @@ static const char	drt_debug_h_id[] =
  #undef  DEBUG
  #define DEBUG	0
 #endif
+
+#include <stdio.h>
 
 #if DEBUG
  #define DL(e)	(opt_debug ? (void)(e) : (void)0)

--- a/include/fpattern/debug.h
+++ b/include/fpattern/debug.h
@@ -38,7 +38,8 @@ static const char	drt_debug_h_id[] =
 #include <stdio.h>
 
 #if DEBUG
- #define DL(e)	(opt_debug ? (void)(e) : (void)0)
+ // #define DL(e)	(opt_debug ? (void)(e) : (void)0)
+ #define DL(e)	((void)(e))
 #else
  #define DL(e)	((void)0)
 #endif


### PR DESCRIPTION
Compilation fails because of undefined `printf` in debug mode

https://github.com/fallout2-ce/fallout2-ce/actions/runs/14954646689/job/42008683066?pr=119

This PR fixes this by adding `#include <stdio.h>`